### PR TITLE
Update role-patch.yaml

### DIFF
--- a/tenant/overlays/saiki/role-patch.yaml
+++ b/tenant/overlays/saiki/role-patch.yaml
@@ -2,3 +2,9 @@
 - op: replace
   path: /metadata/namespace
   value: saiki
+- op: add
+  path: /rules/-
+  value:
+    apiGroups: [""]
+    resources: ["pods/attach", "pods/exec", "endpoints"]
+    verbs: ["get", "list", "create", "update", "delete"]


### PR DESCRIPTION
OnlineButiqueのフロントエンドへのアクセスに失敗する問題の原因調査と解決のために有用となる権限たちを追記しました。エンドポイントがうまく接続されていない可能性があるので、動作確認のためのpods/attachとexec、必要に応じて調整できるようにendpoitntをresourcesとして追加しています。