### PR TITLE
スケジューラに必要な権限の追加

### DIFF
--- a/tenant/base/role.yaml
+++ b/tenant/base/role.yaml
@@ -6,7 +6,7 @@ metadata:
   name: tenant-role
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "configmaps", "persistentvolumeclaims", "secrets", "pods/log", "pods/portforward", "pods/binding", "events", "nodes"]
+  resources: ["pods", "services", "configmaps", "persistentvolumeclaims", "secrets", "pods/log", "pods/portforward", "pods/binding", "events", "nodes", "serviceaccounts"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments"]

--- a/tenant/base/role.yaml
+++ b/tenant/base/role.yaml
@@ -6,7 +6,7 @@ metadata:
   name: tenant-role
 rules:
 - apiGroups: [""]
-  resources: ["pods", "services", "configmaps", "persistentvolumeclaims", "secrets", "pods/log", "pods/portforward"]
+  resources: ["pods", "services", "configmaps", "persistentvolumeclaims", "secrets", "pods/log", "pods/portforward", "pods/binding", "events", "nodes"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments"]

--- a/tenant/base/role.yaml
+++ b/tenant/base/role.yaml
@@ -11,3 +11,6 @@ rules:
 - apiGroups: ["extensions", "apps"]
   resources: ["deployments"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]


### PR DESCRIPTION
 ["pods/binding", "events", "nodes"] -> スケジューラ開発時にいちおう持っておきたい権限です。
["roles", "rolebindings"] -> 上記のような権限をpodに付与し、スケジューラとして動作させるために必要です。
["serviceaccounts”] -> サービスアカウントを介してrolebindingするのに必要です
