### PR TITLE
権限（clusterrolebindings）追加

### DIFF
--- a/tenant/base/role.yaml
+++ b/tenant/base/role.yaml
@@ -12,5 +12,5 @@ rules:
   resources: ["deployments"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["roles", "rolebindings", clusterrolebindings]
+  resources: ["roles", "rolebindings", "clusterrolebindings"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]

--- a/tenant/base/role.yaml
+++ b/tenant/base/role.yaml
@@ -12,5 +12,5 @@ rules:
   resources: ["deployments"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["roles", "rolebindings"]
+  resources: ["roles", "rolebindings", clusterrolebindings]
   verbs: ["get", "list", "watch", "create", "update", "delete"]


### PR DESCRIPTION
以下のエラー解消のため
User "saiki" cannot get resource "clusterrolebindings" in API group "rbac.authorization.k8s.io" at the cluster scope