### PR TITLE
Update cluster-role.yaml

### DIFF
--- a/tenant/base/cluster-role.yaml
+++ b/tenant/base/cluster-role.yaml
@@ -59,7 +59,7 @@ rules:
   resources: ["csidrivers", "csinodes", "csistoragecapacities", "storageclasses"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["clusterrolebindings"]
+  resources: ["clusterroles", "clusterrolebindings"]
   verbs: ["get", "list", "watch", "create", "update", "delete"]
 ---
 # Cluster Role to use descheduler


### PR DESCRIPTION
clusterrolesに対する権限が必要だったので追記しました。
ちなみに、以下のyamlを適用する際に必要になったものです。
https://github.com/kubernetes-sigs/descheduler/blob/master/kubernetes/base/rbac.yaml